### PR TITLE
Render responses as Uint8Array instead of strings

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -1,5 +1,4 @@
 import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
-
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';
 

--- a/files/entry.js
+++ b/files/entry.js
@@ -74,8 +74,7 @@ async function toResponse(rendered) {
 	});
 	
 	const rawBody = new Uint8Array(await rendered.arrayBuffer());
-	console.log("Returning raw byte array");
-
+	
 	return {
 		status,
 		body: rawBody,

--- a/files/entry.js
+++ b/files/entry.js
@@ -1,4 +1,6 @@
 import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
+import {is_text} from '@sveltejs/kit/runtime/server/endpoint';
+
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';
 
@@ -72,7 +74,16 @@ async function toResponse(rendered) {
 		resHeaders[key] = value;
 	});
 	
-	if (resHeaders['content-type'] == 'image/jpeg') {
+	if (is_text(resHeaders['content-type'])) {
+		const resBody = await rendered.text();
+		console.log("Returning text");
+
+		return {
+			status,
+			body: resBody,
+			headers: resHeaders,
+		};
+	} else {
 		const rawBody = new Uint8Array(await rendered.arrayBuffer());
 		console.log("Returning raw byte array");
 
@@ -82,16 +93,5 @@ async function toResponse(rendered) {
 			headers: resHeaders,
 			isRaw: true
 		};
-	} else {
-		const resBody = await rendered.text();
-		console.log("Returning text");
-
-		return {
-			status,
-			body: resBody,
-			headers: resHeaders,
-		};
 	}
-	
-	
 }

--- a/files/entry.js
+++ b/files/entry.js
@@ -65,20 +65,33 @@ function toRequest(context) {
  */
 async function toResponse(rendered) {
 	const { status } = rendered;
-	const resBody = await rendered.text();
-
+	
 	/** @type {Record<string, string>} */
 	const resHeaders = {};
 	rendered.headers.forEach((value, key) => {
 		resHeaders[key] = value;
 	});
-
-	console.log(resHeaders);
 	
-	return {
-		status,
-		body: resBody,
-		headers: resHeaders,
-		isRaw: true
-	};
+	if (resHeaders['content-type'] == 'image/jpeg') {
+		const rawBody = new Uint8Array(await rendered.arrayBuffer());
+		console.log("Returning raw byte array");
+
+		return {
+			status,
+			body: rawBody,
+			headers: resHeaders,
+			isRaw: true
+		};
+	} else {
+		const resBody = await rendered.text();
+		console.log("Returning text");
+
+		return {
+			status,
+			body: resBody,
+			headers: resHeaders,
+		};
+	}
+	
+	
 }

--- a/files/entry.js
+++ b/files/entry.js
@@ -66,18 +66,17 @@ function toRequest(context) {
  */
 async function toResponse(rendered) {
 	const { status } = rendered;
-	
+	const resBody = new Uint8Array(await rendered.arrayBuffer());
+
 	/** @type {Record<string, string>} */
 	const resHeaders = {};
 	rendered.headers.forEach((value, key) => {
 		resHeaders[key] = value;
 	});
-	
-	const rawBody = new Uint8Array(await rendered.arrayBuffer());
-	
+
 	return {
 		status,
-		body: rawBody,
+		body: resBody,
 		headers: resHeaders,
 		isRaw: true
 	};

--- a/files/entry.js
+++ b/files/entry.js
@@ -1,5 +1,4 @@
 import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
-import {is_text} from '@sveltejs/kit/assets/server';
 
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';
@@ -74,24 +73,13 @@ async function toResponse(rendered) {
 		resHeaders[key] = value;
 	});
 	
-	if (is_text(resHeaders['content-type'])) {
-		const resBody = await rendered.text();
-		console.log("Returning text");
+	const rawBody = new Uint8Array(await rendered.arrayBuffer());
+	console.log("Returning raw byte array");
 
-		return {
-			status,
-			body: resBody,
-			headers: resHeaders,
-		};
-	} else {
-		const rawBody = new Uint8Array(await rendered.arrayBuffer());
-		console.log("Returning raw byte array");
-
-		return {
-			status,
-			body: rawBody,
-			headers: resHeaders,
-			isRaw: true
-		};
-	}
+	return {
+		status,
+		body: rawBody,
+		headers: resHeaders,
+		isRaw: true
+	};
 }

--- a/files/entry.js
+++ b/files/entry.js
@@ -1,5 +1,5 @@
 import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
-import {is_text} from '@sveltejs/kit/runtime/server/endpoint';
+import {is_text} from '@sveltejs/kit/assets/server';
 
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';

--- a/files/entry.js
+++ b/files/entry.js
@@ -76,6 +76,7 @@ async function toResponse(rendered) {
 	return {
 		status,
 		body: resBody,
-		headers: resHeaders
+		headers: resHeaders,
+		isRaw: resHeaders['Content-Type'] == 'image/jpeg'
 	};
 }

--- a/files/entry.js
+++ b/files/entry.js
@@ -73,10 +73,12 @@ async function toResponse(rendered) {
 		resHeaders[key] = value;
 	});
 
+	console.log(resHeaders);
+	
 	return {
 		status,
 		body: resBody,
 		headers: resHeaders,
-		isRaw: resHeaders['Content-Type'] == 'image/jpeg'
+		isRaw: true
 	};
 }


### PR DESCRIPTION
Update `toResponse` to return a byte array and set isRaw on the response object. SvelteKit is already handling encoding and setting content types, so the adapter should pass the raw response body directly to the function. This allows serving binary responses such as images from endpoints.